### PR TITLE
Fix the usage to properly list color first, and THEN pattern

### DIFF
--- a/highlight
+++ b/highlight
@@ -136,7 +136,7 @@ sub print_usage {
     print<<EOT;
 Usage: $0 [-i] [--color=COLOR_STRING] [--] <PATTERN0> [PATTERN1...]
   or
-Usage: $0 [-i] [--filter PATTERN,COLOR] [--filter PATTERN,COLOR]
+Usage: $0 [-i] [--filter COLOR,PATTERN] [--filter COLOR,PATTERN] ...
 
 This is highlight version $VERSION.
 


### PR DESCRIPTION
Some how the usage didn't get properly updated in 640dc3b.
